### PR TITLE
Car license plate validation

### DIFF
--- a/src/Flunt.Br/Extensions/CarLicensePlateExtension.cs
+++ b/src/Flunt.Br/Extensions/CarLicensePlateExtension.cs
@@ -11,5 +11,19 @@ namespace Flunt.Br.Extensions
                 contract.AddNotification(property, message);
             return contract;
         }
+
+        public static Contract IsMercosulCarLicensePlate(this Contract contract, string value, string property, string message)
+        {
+            if (string.IsNullOrEmpty(value) || !new MercosulCarLicensePlate().Validate(value))
+                contract.AddNotification(property, message);
+            return contract;
+        }
+
+        public static Contract IsOldCarLicensePlate(this Contract contract, string value, string property, string message)
+        {
+            if (string.IsNullOrEmpty(value) || !new OldCarLicensePlate().Validate(value))
+                contract.AddNotification(property, message);
+            return contract;
+        }
     }
 }

--- a/src/Flunt.Br/Extensions/CarLicensePlateExtension.cs
+++ b/src/Flunt.Br/Extensions/CarLicensePlateExtension.cs
@@ -1,0 +1,15 @@
+using Flunt.Br.Validations;
+using Flunt.Validations;
+
+namespace Flunt.Br.Extensions
+{
+    public static partial class ContractExtensions
+    {
+        public static Contract IsCarLicensePlate(this Contract contract, string value, string property, string message)
+        {
+            if (string.IsNullOrEmpty(value) || !new CarLicensePlate().Validate(value))
+                contract.AddNotification(property, message);
+            return contract;
+        }
+    }
+}

--- a/src/Flunt.Br/Validations/CarLicensePlate.cs
+++ b/src/Flunt.Br/Validations/CarLicensePlate.cs
@@ -1,0 +1,13 @@
+﻿using Flunt.Br.Document.Interfaces;
+using System.Text.RegularExpressions;
+
+namespace Flunt.Br.Validations
+{
+    internal class CarLicensePlate : IValidate
+    {
+        public bool Validate(string value)
+        {
+            return value.Length == 7 && new Regex(@"[A-Z]{3}[0-9][A-Z][0-9]{2}", RegexOptions.Singleline).Match(value).Success;
+        }
+    }
+}

--- a/src/Flunt.Br/Validations/CarLicensePlate.cs
+++ b/src/Flunt.Br/Validations/CarLicensePlate.cs
@@ -7,7 +7,7 @@ namespace Flunt.Br.Validations
     {
         public bool Validate(string value)
         {
-            return value.Length == 7 && new Regex(@"[A-Z]{3}[0-9][A-Z0-9][0-9]{2}", RegexOptions.Singleline).Match(value).Success;
+            return (value.Length == 7 || value.Length == 8) && new Regex(@"[A-Z]{3}\-?[0-9][A-Z0-9][0-9]{2}", RegexOptions.Singleline).Match(value).Success;
         }
     }
 }

--- a/src/Flunt.Br/Validations/CarLicensePlate.cs
+++ b/src/Flunt.Br/Validations/CarLicensePlate.cs
@@ -7,7 +7,7 @@ namespace Flunt.Br.Validations
     {
         public bool Validate(string value)
         {
-            return value.Length == 7 && new Regex(@"[A-Z]{3}[0-9][A-Z][0-9]{2}", RegexOptions.Singleline).Match(value).Success;
+            return value.Length == 7 && new Regex(@"[A-Z]{3}[0-9][A-Z0-9][0-9]{2}", RegexOptions.Singleline).Match(value).Success;
         }
     }
 }

--- a/src/Flunt.Br/Validations/MercosulCarLicensePlate.cs
+++ b/src/Flunt.Br/Validations/MercosulCarLicensePlate.cs
@@ -1,0 +1,13 @@
+using Flunt.Br.Document.Interfaces;
+using System.Text.RegularExpressions;
+
+namespace Flunt.Br.Validations
+{
+    internal class MercosulCarLicensePlate : IValidate
+    {
+        public bool Validate(string value)
+        {
+            return value.Length == 7 && new Regex(@"[A-Z]{3}[0-9][A-Z][0-9]{2}", RegexOptions.Singleline).Match(value).Success;
+        }
+    }
+}

--- a/src/Flunt.Br/Validations/MercosulCarLicensePlate.cs
+++ b/src/Flunt.Br/Validations/MercosulCarLicensePlate.cs
@@ -7,7 +7,7 @@ namespace Flunt.Br.Validations
     {
         public bool Validate(string value)
         {
-            return value.Length == 7 && new Regex(@"[A-Z]{3}[0-9][A-Z][0-9]{2}", RegexOptions.Singleline).Match(value).Success;
+            return value.Length == 7 && new Regex(@"[A-Z]{3}\-?[0-9][A-Z][0-9]{2}", RegexOptions.Singleline).Match(value).Success;
         }
     }
 }

--- a/src/Flunt.Br/Validations/MercosulCarLicensePlate.cs
+++ b/src/Flunt.Br/Validations/MercosulCarLicensePlate.cs
@@ -7,7 +7,7 @@ namespace Flunt.Br.Validations
     {
         public bool Validate(string value)
         {
-            return value.Length == 7 && new Regex(@"[A-Z]{3}\-?[0-9][A-Z][0-9]{2}", RegexOptions.Singleline).Match(value).Success;
+            return (value.Length == 7 || value.Length == 8) && new Regex(@"[A-Z]{3}\-?[0-9][A-Z][0-9]{2}", RegexOptions.Singleline).Match(value).Success;
         }
     }
 }

--- a/src/Flunt.Br/Validations/OldCarLicensePlate.cs
+++ b/src/Flunt.Br/Validations/OldCarLicensePlate.cs
@@ -1,0 +1,13 @@
+using Flunt.Br.Document.Interfaces;
+using System.Text.RegularExpressions;
+
+namespace Flunt.Br.Validations
+{
+    internal class OldCarLicensePlate : IValidate
+    {
+        public bool Validate(string value)
+        {
+            return value.Length == 7 && new Regex(@"[A-Z]{3}[0-9][0-9][0-9]{2}", RegexOptions.Singleline).Match(value).Success;
+        }
+    }
+}

--- a/src/Flunt.Br/Validations/OldCarLicensePlate.cs
+++ b/src/Flunt.Br/Validations/OldCarLicensePlate.cs
@@ -7,7 +7,7 @@ namespace Flunt.Br.Validations
     {
         public bool Validate(string value)
         {
-            return value.Length == 7 && new Regex(@"[A-Z]{3}[0-9][0-9][0-9]{2}", RegexOptions.Singleline).Match(value).Success;
+            return (value.Length == 7 || value.Length == 8) && new Regex(@"[A-Z]{3}\-?[0-9]{4}", RegexOptions.Singleline).Match(value).Success;
         }
     }
 }

--- a/tests/Flunt.Br.Tests/CarLicensePlateTest.cs
+++ b/tests/Flunt.Br.Tests/CarLicensePlateTest.cs
@@ -70,6 +70,7 @@ namespace Flunt.Br.Tests
         [DataRow("KDA1E18")]
         [DataRow("LOL8Y11")]
         [DataRow("LMA0I11")]
+        [DataRow("LMA-0I11")]
         public void ShouldBeAbleToReturnTrueGivingValidCarLicensePlate(string value)
         {
             //Arrange
@@ -93,6 +94,7 @@ namespace Flunt.Br.Tests
         [DataRow("KDA1718")]
         [DataRow("LOL8811")]
         [DataRow("LMA0611")]
+        [DataRow("LMA-0611")]
         public void ShouldBeAbleToReturnTrueGivingValidOldCarLicensePlate(string value)
         {
             //Arrange
@@ -116,6 +118,9 @@ namespace Flunt.Br.Tests
         [DataRow("KDA118")]
         [DataRow("DLC94Z6")]
         [DataRow("LMA0I11")]
+        [DataRow("LMA0--11")]        
+        [DataRow("LMA--0611")]
+        [DataRow("LMA-061")]
         public void ShouldBeAbleToReturnFalseGivingInvalidPatternOldCarLicensePlate(string value)
         {
             //Arrange
@@ -139,6 +144,7 @@ namespace Flunt.Br.Tests
         [DataRow("KDA1E18")]
         [DataRow("LOL8Y11")]
         [DataRow("LMA0I11")]
+        [DataRow("LMA-0I11")]
         public void ShouldBeAbleToReturnTrueGivingValidMercosulCarLicensePlate(string value)
         {
             //Arrange

--- a/tests/Flunt.Br.Tests/CarLicensePlateTest.cs
+++ b/tests/Flunt.Br.Tests/CarLicensePlateTest.cs
@@ -11,12 +11,12 @@ namespace Flunt.Br.Tests
         private static string CAR_LICENSE_PLATE_PROPERTY = "carlicenseplate";
 
         [TestMethod]
-        [DataRow("ABC1A1")]        
+        [DataRow("ABC1A1")]
         public void ShouldBeAbleToReturnFalseGivingCarLicensePlateWithLessThan7Characters(string value)
         {
             //Arrange
             var contract = new Contract();
-            
+
             //Act
             var actual = contract.IsCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
 
@@ -24,19 +24,19 @@ namespace Flunt.Br.Tests
             Assert.IsFalse(actual.Valid);
         }
 
-        [TestMethod]              
-        [DataRow("1111ABC")]        
-        [DataRow("AB11ABC")]    
-        [DataRow("1ABCDEF")]    
-        [DataRow("A1BCABC")]    
-        [DataRow("DLCZ946")]    
-        [DataRow("DLC94Z6")]    
-        [DataRow("DLC946Z")]    
+        [TestMethod]
+        [DataRow("1111ABC")]
+        [DataRow("AB11ABC")]
+        [DataRow("1ABCDEF")]
+        [DataRow("A1BCABC")]
+        [DataRow("DLCZ946")]
+        [DataRow("DLC94Z6")]
+        [DataRow("DLC946Z")]
         public void ShouldBeAbleToReturnFalseGivingInvalidPatternCarLicensePlate(string value)
         {
             //Arrange
             var contract = new Contract();
-            
+
             //Act
             var actual = contract.IsCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
 
@@ -44,14 +44,14 @@ namespace Flunt.Br.Tests
             Assert.IsFalse(actual.Valid);
         }
 
-        [TestMethod]        
-        [DataRow("")]        
+        [TestMethod]
+        [DataRow("")]
         [DataRow(null)]
         public void ShouldBeAbleToReturnFalseGivingEmptyCarLicensePlate(string value)
         {
-           //Arrange
+            //Arrange
             var contract = new Contract();
-            
+
             //Act
             var actual = contract.IsCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
 
@@ -59,27 +59,116 @@ namespace Flunt.Br.Tests
             Assert.IsFalse(actual.Valid);
         }
 
-        [TestMethod]        
-        [DataRow("GAG1A11")]  
-        [DataRow("RAR2150")]  
-        [DataRow("LOL9999")]  
-        [DataRow("ABC1111")]  
-        [DataRow("ABC1A23")]                
-        [DataRow("DLC9Z46")]    
-        [DataRow("IVY1X99")]    
-        [DataRow("KDA1E18")]    
-        [DataRow("LOL8Y11")]    
-        [DataRow("LMA0I11")]    
+        [TestMethod]
+        [DataRow("GAG1A11")]
+        [DataRow("RAR2150")]
+        [DataRow("LOL9999")]
+        [DataRow("ABC1111")]
+        [DataRow("ABC1A23")]
+        [DataRow("DLC9Z46")]
+        [DataRow("IVY1X99")]
+        [DataRow("KDA1E18")]
+        [DataRow("LOL8Y11")]
+        [DataRow("LMA0I11")]
         public void ShouldBeAbleToReturnTrueGivingValidCarLicensePlate(string value)
         {
             //Arrange
             var contract = new Contract();
-            
+
             //Act
             var actual = contract.IsCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
 
             //Assert            
             Assert.IsTrue(actual.Valid);
+        }
+
+        [TestMethod]
+        [DataRow("GAG1111")]
+        [DataRow("RAR2150")]
+        [DataRow("LOL9999")]
+        [DataRow("ABC1111")]
+        [DataRow("ABC1223")]
+        [DataRow("DLC9946")]
+        [DataRow("IVY1499")]
+        [DataRow("KDA1718")]
+        [DataRow("LOL8811")]
+        [DataRow("LMA0611")]
+        public void ShouldBeAbleToReturnTrueGivingValidOldCarLicensePlate(string value)
+        {
+            //Arrange
+            var contract = new Contract();
+
+            //Act
+            var actual = contract.IsOldCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
+
+            //Assert            
+            Assert.IsTrue(actual.Valid);
+        }
+
+        [TestMethod]
+        [DataRow(" ")]
+        [DataRow("")]
+        [DataRow(null)]
+        [DataRow("ABC1K11")]
+        [DataRow("ABC1R23")]
+        [DataRow("DLC9E46")]
+        [DataRow("IVY19")]
+        [DataRow("KDA118")]
+        [DataRow("DLC94Z6")]
+        [DataRow("LMA0I11")]
+        public void ShouldBeAbleToReturnFalseGivingInvalidPatternOldCarLicensePlate(string value)
+        {
+            //Arrange
+            var contract = new Contract();
+
+            //Act
+            var actual = contract.IsOldCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
+
+            //Assert            
+            Assert.IsFalse(actual.Valid);
+        }
+
+        [TestMethod]
+        [DataRow("GAG1A11")]
+        [DataRow("RAR2R50")]
+        [DataRow("LOL9F99")]
+        [DataRow("ABC1Z11")]
+        [DataRow("ABC1A23")]
+        [DataRow("DLC9Z46")]
+        [DataRow("IVY1X99")]
+        [DataRow("KDA1E18")]
+        [DataRow("LOL8Y11")]
+        [DataRow("LMA0I11")]
+        public void ShouldBeAbleToReturnTrueGivingValidMercosulCarLicensePlate(string value)
+        {
+            //Arrange
+            var contract = new Contract();
+
+            //Act
+            var actual = contract.IsMercosulCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
+
+            //Assert            
+            Assert.IsTrue(actual.Valid);
+        }
+
+        [TestMethod]
+        [DataRow("1111ABC")]
+        [DataRow("AB11ABC")]
+        [DataRow("1ABCDEF")]
+        [DataRow("A1BCABC")]
+        [DataRow("DLCZ946")]
+        [DataRow("DLC94Z6")]
+        [DataRow("DLC946Z")]
+        public void ShouldBeAbleToReturnFalseGivingInvalidPatternMercosulCarLicensePlate(string value)
+        {
+            //Arrange
+            var contract = new Contract();
+
+            //Act
+            var actual = contract.IsMercosulCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
+
+            //Assert            
+            Assert.IsFalse(actual.Valid);
         }
     }
 }

--- a/tests/Flunt.Br.Tests/CarLicensePlateTest.cs
+++ b/tests/Flunt.Br.Tests/CarLicensePlateTest.cs
@@ -12,7 +12,7 @@ namespace Flunt.Br.Tests
 
         [TestMethod]
         [DataRow("ABC1A1")]        
-        public void ShouldBeAbleToReturnFalseGivinCarLicensePlateWithLessThan7Characters(string value)
+        public void ShouldBeAbleToReturnFalseGivingCarLicensePlateWithLessThan7Characters(string value)
         {
             //Arrange
             var contract = new Contract();
@@ -33,7 +33,7 @@ namespace Flunt.Br.Tests
         [DataRow("DLCZ946")]    
         [DataRow("DLC94Z6")]    
         [DataRow("DLC946Z")]    
-        public void ShouldBeAbleToReturnFalseGivinInvalidPatternCarLicensePlate(string value)
+        public void ShouldBeAbleToReturnFalseGivingInvalidPatternCarLicensePlate(string value)
         {
             //Arrange
             var contract = new Contract();
@@ -48,7 +48,7 @@ namespace Flunt.Br.Tests
         [TestMethod]        
         [DataRow("")]        
         [DataRow(null)]
-        public void ShouldBeAbleToReturnFalseGivinEmptyCarLicensePlate(string value)
+        public void ShouldBeAbleToReturnFalseGivingEmptyCarLicensePlate(string value)
         {
            //Arrange
             var contract = new Contract();
@@ -67,7 +67,7 @@ namespace Flunt.Br.Tests
         [DataRow("KDA1E18")]    
         [DataRow("LOL8Y11")]    
         [DataRow("LMA0I11")]    
-        public void ShouldBeAbleToReturnTrueGivinValidCarLicensePlate(string value)
+        public void ShouldBeAbleToReturnTrueGivingValidCarLicensePlate(string value)
         {
             //Arrange
             var contract = new Contract();

--- a/tests/Flunt.Br.Tests/CarLicensePlateTest.cs
+++ b/tests/Flunt.Br.Tests/CarLicensePlateTest.cs
@@ -24,8 +24,7 @@ namespace Flunt.Br.Tests
             Assert.IsFalse(actual.Valid);
         }
 
-        [TestMethod]
-        [DataRow("ABC1111")]        
+        [TestMethod]              
         [DataRow("1111ABC")]        
         [DataRow("AB11ABC")]    
         [DataRow("1ABCDEF")]    
@@ -61,6 +60,10 @@ namespace Flunt.Br.Tests
         }
 
         [TestMethod]        
+        [DataRow("GAG1A11")]  
+        [DataRow("RAR2150")]  
+        [DataRow("LOL9999")]  
+        [DataRow("ABC1111")]  
         [DataRow("ABC1A23")]                
         [DataRow("DLC9Z46")]    
         [DataRow("IVY1X99")]    

--- a/tests/Flunt.Br.Tests/CarLicensePlateTest.cs
+++ b/tests/Flunt.Br.Tests/CarLicensePlateTest.cs
@@ -1,0 +1,82 @@
+using Flunt.Br.Extensions;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Flunt.Validations;
+
+namespace Flunt.Br.Tests
+{
+    [TestClass]
+    public class CarLicensePlateTest
+    {
+        private static string INVALID_CAR_LICENSE_PLATE_ERROR = "Invalid Car License Plate";
+        private static string CAR_LICENSE_PLATE_PROPERTY = "carlicenseplate";
+
+        [TestMethod]
+        [DataRow("ABC1A1")]        
+        public void ShouldBeAbleToReturnFalseGivinCarLicensePlateWithLessThan7Characters(string value)
+        {
+            //Arrange
+            var contract = new Contract();
+            
+            //Act
+            var actual = contract.IsCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
+
+            //Assert            
+            Assert.IsFalse(actual.Valid);
+        }
+
+        [TestMethod]
+        [DataRow("ABC1111")]        
+        [DataRow("1111ABC")]        
+        [DataRow("AB11ABC")]    
+        [DataRow("1ABCDEF")]    
+        [DataRow("A1BCABC")]    
+        [DataRow("DLCZ946")]    
+        [DataRow("DLC94Z6")]    
+        [DataRow("DLC946Z")]    
+        public void ShouldBeAbleToReturnFalseGivinInvalidPatternCarLicensePlate(string value)
+        {
+            //Arrange
+            var contract = new Contract();
+            
+            //Act
+            var actual = contract.IsCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
+
+            //Assert            
+            Assert.IsFalse(actual.Valid);
+        }
+
+        [TestMethod]        
+        [DataRow("")]        
+        [DataRow(null)]
+        public void ShouldBeAbleToReturnFalseGivinEmptyCarLicensePlate(string value)
+        {
+           //Arrange
+            var contract = new Contract();
+            
+            //Act
+            var actual = contract.IsCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
+
+            //Assert            
+            Assert.IsFalse(actual.Valid);
+        }
+
+        [TestMethod]        
+        [DataRow("ABC1A23")]                
+        [DataRow("DLC9Z46")]    
+        [DataRow("IVY1X99")]    
+        [DataRow("KDA1E18")]    
+        [DataRow("LOL8Y11")]    
+        [DataRow("LMA0I11")]    
+        public void ShouldBeAbleToReturnTrueGivinValidCarLicensePlate(string value)
+        {
+            //Arrange
+            var contract = new Contract();
+            
+            //Act
+            var actual = contract.IsCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
+
+            //Assert            
+            Assert.IsTrue(actual.Valid);
+        }
+    }
+}


### PR DESCRIPTION
Segundo o [Wikipédia](https://pt.wikipedia.org/wiki/Placas_de_identifica%C3%A7%C3%A3o_de_ve%C3%ADculos_no_Mercosul#_Brasil) o padrão das placas brasileiras é `ABC1A23`.

Foi implementado o método de extensão do Contract e criado a validação da placa veicular.

Fico aberto a sugestões de melhorias, de como organizar os commits (se precisar que faça um squash deles) e de um review.