### PR TITLE
Fixing change breaks caused by the new version of Flunt

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ bld/
 !.vscode/launch.json
 !.vscode/extensions.json
 .vs/
+.idea/
 .history

--- a/src/Flunt.Br/Contract.cs
+++ b/src/Flunt.Br/Contract.cs
@@ -1,0 +1,13 @@
+using Flunt.Validations;
+
+namespace Flunt.Br
+{
+    /// <summary>
+    /// This class extends the Contract<T> of Flunt Package
+    /// To avoid breack changes
+    /// </summary>
+    public class Contract: Contract<bool>
+    {
+        
+    }
+}

--- a/src/Flunt.Br/Contract.cs
+++ b/src/Flunt.Br/Contract.cs
@@ -6,8 +6,5 @@ namespace Flunt.Br
     /// This class extends the Contract<T> of Flunt Package
     /// To avoid breack changes
     /// </summary>
-    public class Contract: Contract<bool>
-    {
-        
-    }
+    public class Contract: Contract<bool> { }
 }

--- a/src/Flunt.Br/Flunt.Br.csproj
+++ b/src/Flunt.Br/Flunt.Br.csproj
@@ -1,22 +1,28 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
-    <Version>1.4.1</Version>
-    <Authors>Alan Lira</Authors>
-    <Description>Extensions of Flunt for Brazilian projects</Description>
-    <PackageLicenseExpression>MIT</PackageLicenseExpression>
-    <PackageProjectUrl>https://github.com/lira92/flunt.br</PackageProjectUrl>
-    <RepositoryUrl>https://github.com/lira92/flunt.br</RepositoryUrl>
-    <AssemblyVersion>1.4.1.0</AssemblyVersion>
-    <FileVersion>1.4.1.0</FileVersion>
-    <PackageIcon>flunt-icon-br_compressed.png</PackageIcon>
-    <PackageTags>Validation;Flunt.Br;Flunt;Cnpj;Cpf;Telefone;Cep</PackageTags>
-  </PropertyGroup>
-  <ItemGroup>
-    <PackageReference Include="Flunt" Version="1.0.4" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\assets\flunt-icon-br_compressed.png" Pack="true" PackagePath="\"/>
-  </ItemGroup>
+    <PropertyGroup>
+        <TargetFramework>netstandard2.0</TargetFramework>
+        <Version>1.4.1</Version>
+        <Authors>Alan Lira</Authors>
+        <Description>Extensions of Flunt for Brazilian projects</Description>
+        <PackageLicenseExpression>MIT</PackageLicenseExpression>
+        <PackageProjectUrl>https://github.com/lira92/flunt.br</PackageProjectUrl>
+        <RepositoryUrl>https://github.com/lira92/flunt.br</RepositoryUrl>
+        <AssemblyVersion>1.4.1.0</AssemblyVersion>
+        <FileVersion>1.4.1.0</FileVersion>
+        <PackageIcon>flunt-icon-br_compressed.png</PackageIcon>
+        <PackageTags>Validation;Flunt.Br;Flunt;Cnpj;Cpf;Telefone;Cep</PackageTags>
+    </PropertyGroup>
+    
+    <ItemGroup Label="Flunt">
+        <PackageReference Include="Flunt" Version="2.0.3"/>
+    </ItemGroup>
+
+    <ItemGroup Label="Package Asserts">
+        <None Include="..\..\assets\flunt-icon-br_compressed.png">
+            <Pack>true</Pack>
+            <PackagePath>/</PackagePath>
+            <Link>flunt-icon-br_compressed.png</Link>
+        </None>
+    </ItemGroup>
 </Project>

--- a/tests/Flunt.Br.Tests/BankContractTest.cs
+++ b/tests/Flunt.Br.Tests/BankContractTest.cs
@@ -1,6 +1,4 @@
-using Flunt.Br.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Flunt.Validations;
 
 namespace Flunt.Br.Tests
 {
@@ -17,7 +15,7 @@ namespace Flunt.Br.Tests
         {
             var wrong = new Contract()
                 .IsCreditCard(value, "document", "Invalid document");
-            Assert.IsFalse(wrong.Valid);
+            Assert.IsFalse(wrong.IsValid);
         }
 
         [TestMethod]
@@ -29,7 +27,7 @@ namespace Flunt.Br.Tests
         {
             var right = new Contract()
                 .IsCreditCard(value, "document", "Invalid document");
-            Assert.IsTrue(right.Valid);
+            Assert.IsTrue(right.IsValid);
         }
     }
 }

--- a/tests/Flunt.Br.Tests/BankContractTest.cs
+++ b/tests/Flunt.Br.Tests/BankContractTest.cs
@@ -1,3 +1,4 @@
+using System;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 
 namespace Flunt.Br.Tests
@@ -10,13 +11,21 @@ namespace Flunt.Br.Tests
         [DataRow("521586453135936245")]
         [DataRow("601138410090657947")]
         [DataRow("3559716521958")]
-        [DataRow(null)]
         public void IsCreditCard_Invalid(string value)
         {
             var wrong = new Contract()
                 .IsCreditCard(value, "document", "Invalid document");
             Assert.IsFalse(wrong.IsValid);
         }
+        
+        [TestMethod]
+        [ExpectedException(typeof(ArgumentNullException))]
+        public void IsCreditCard_Exception()
+        {
+            var wrong = new Contract()
+                .IsCreditCard(null, "document", "Invalid document");
+            Assert.IsFalse(wrong.IsValid);
+        }        
 
         [TestMethod]
         [DataRow("4024007140542043")]

--- a/tests/Flunt.Br.Tests/CarLicensePlateTest.cs
+++ b/tests/Flunt.Br.Tests/CarLicensePlateTest.cs
@@ -1,6 +1,5 @@
 using Flunt.Br.Extensions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using Flunt.Validations;
 
 namespace Flunt.Br.Tests
 {
@@ -21,7 +20,7 @@ namespace Flunt.Br.Tests
             var actual = contract.IsCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
 
             //Assert            
-            Assert.IsFalse(actual.Valid);
+            Assert.IsFalse(actual.IsValid);
         }
 
         [TestMethod]
@@ -41,7 +40,7 @@ namespace Flunt.Br.Tests
             var actual = contract.IsCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
 
             //Assert            
-            Assert.IsFalse(actual.Valid);
+            Assert.IsFalse(actual.IsValid);
         }
 
         [TestMethod]
@@ -56,7 +55,7 @@ namespace Flunt.Br.Tests
             var actual = contract.IsCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
 
             //Assert            
-            Assert.IsFalse(actual.Valid);
+            Assert.IsFalse(actual.IsValid);
         }
 
         [TestMethod]
@@ -80,7 +79,7 @@ namespace Flunt.Br.Tests
             var actual = contract.IsCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
 
             //Assert            
-            Assert.IsTrue(actual.Valid);
+            Assert.IsTrue(actual.IsValid);
         }
 
         [TestMethod]
@@ -104,7 +103,7 @@ namespace Flunt.Br.Tests
             var actual = contract.IsOldCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
 
             //Assert            
-            Assert.IsTrue(actual.Valid);
+            Assert.IsTrue(actual.IsValid);
         }
 
         [TestMethod]
@@ -130,7 +129,7 @@ namespace Flunt.Br.Tests
             var actual = contract.IsOldCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
 
             //Assert            
-            Assert.IsFalse(actual.Valid);
+            Assert.IsFalse(actual.IsValid);
         }
 
         [TestMethod]
@@ -154,7 +153,7 @@ namespace Flunt.Br.Tests
             var actual = contract.IsMercosulCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
 
             //Assert            
-            Assert.IsTrue(actual.Valid);
+            Assert.IsTrue(actual.IsValid);
         }
 
         [TestMethod]
@@ -174,7 +173,7 @@ namespace Flunt.Br.Tests
             var actual = contract.IsMercosulCarLicensePlate(value, CAR_LICENSE_PLATE_PROPERTY, INVALID_CAR_LICENSE_PLATE_ERROR);
 
             //Assert            
-            Assert.IsFalse(actual.Valid);
+            Assert.IsFalse(actual.IsValid);
         }
     }
 }

--- a/tests/Flunt.Br.Tests/Flunt.Br.Tests.csproj
+++ b/tests/Flunt.Br.Tests/Flunt.Br.Tests.csproj
@@ -1,14 +1,14 @@
 ﻿<?xml version="1.0" encoding="utf-8" standalone="yes"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
-    <PackageReference Include="Flunt" Version="1.0.4" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.2.5" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.2.5" />
+    <PackageReference Include="Flunt" Version="2.0.3" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\src\Flunt.Br\Flunt.Br.csproj" />

--- a/tests/Flunt.Br.Tests/PersonContractTest.cs
+++ b/tests/Flunt.Br.Tests/PersonContractTest.cs
@@ -26,7 +26,7 @@ namespace Flunt.Br.Tests
         {
             var wrong = new Contract()
                 .IsCpf(value, "document", "Invalid document");
-            Assert.AreEqual(false, wrong.Valid);
+            Assert.AreEqual(false, wrong.IsValid);
         }
 
         [TestMethod]
@@ -36,7 +36,7 @@ namespace Flunt.Br.Tests
         {
             var right = new Contract()
                 .IsCpf(value, "document", "Invalid document");
-            Assert.AreEqual(true, right.Valid);
+            Assert.AreEqual(true, right.IsValid);
         }
         
         [TestMethod]
@@ -71,7 +71,7 @@ namespace Flunt.Br.Tests
         {
             var wrong = new Contract()
                 .IsCnpjOrCPF(value, "document", "Invalid document");
-            Assert.IsFalse(wrong.Valid);
+            Assert.IsFalse(wrong.IsValid);
         }
 
         [TestMethod]
@@ -83,7 +83,7 @@ namespace Flunt.Br.Tests
         {
             var right = new Contract()
                 .IsCnpjOrCPF(value, "document", "Invalid document");
-            Assert.IsTrue(right.Valid);
+            Assert.IsTrue(right.IsValid);
         }
 
 
@@ -107,7 +107,7 @@ namespace Flunt.Br.Tests
         {
             var wrong = new Contract()
                 .IsCnpj(value, "document", "Invalid document");
-            Assert.IsFalse(wrong.Valid);
+            Assert.IsFalse(wrong.IsValid);
         }
 
         [TestMethod]
@@ -117,7 +117,7 @@ namespace Flunt.Br.Tests
         {
             var right = new Contract()
                 .IsCnpj(value, "document", "Invalid document");
-            Assert.IsTrue(right.Valid);
+            Assert.IsTrue(right.IsValid);
         }
 
         [TestMethod]
@@ -129,7 +129,7 @@ namespace Flunt.Br.Tests
         {
             var wrong = new Contract()
                 .IsVoterDocument(value, "document", "Invalid document");
-            Assert.IsFalse(wrong.Valid);
+            Assert.IsFalse(wrong.IsValid);
         }
 
         [TestMethod]
@@ -140,7 +140,7 @@ namespace Flunt.Br.Tests
         {
             var right = new Contract()
                 .IsVoterDocument(value, "document", "Invalid document");
-            Assert.IsTrue(right.Valid);
+            Assert.IsTrue(right.IsValid);
         }
 
 
@@ -153,7 +153,7 @@ namespace Flunt.Br.Tests
         {
             var wrong = new Contract()
                 .IsCnh(value, "document", "Invalid document");
-            Assert.IsFalse(wrong.Valid);
+            Assert.IsFalse(wrong.IsValid);
         }
 
         [TestMethod]
@@ -164,7 +164,7 @@ namespace Flunt.Br.Tests
         {
             var right = new Contract()
                 .IsCnh(value, "document", "Invalid document");
-            Assert.IsTrue(right.Valid);
+            Assert.IsTrue(right.IsValid);
         }
     }
 }

--- a/tests/Flunt.Br.Tests/PhoneContractTest.cs
+++ b/tests/Flunt.Br.Tests/PhoneContractTest.cs
@@ -55,7 +55,7 @@ namespace Flunt.Br.Tests
         {
             var wrong = new Contract()
                 .IsPhone(value, "phone", "Invalid phone");
-            Assert.IsFalse(wrong.Valid);
+            Assert.IsFalse(wrong.IsValid);
         }
 
         [TestMethod]
@@ -118,11 +118,11 @@ namespace Flunt.Br.Tests
         [DataRow("+55 999999-9999")]
         [DataRow("+55 9999999999")]
         [DataRow("+55 99 9999 9999")]
-        public void IsPhone_Valid(string value)
+        public void IsPhone_IsValid(string value)
         {
             var right = new Contract()
                 .IsPhone(value, "phone", "Invalid phone");
-            Assert.IsTrue(right.Valid);
+            Assert.IsTrue(right.IsValid);
         }
 
         [TestMethod]
@@ -168,11 +168,11 @@ namespace Flunt.Br.Tests
         [DataRow("+55 99999999999", "+55 99999999999")]
         [DataRow("+55 99 9999 9999", "+55 99 9999 9999")]
         [DataRow("+55 99 99999 9999", "+55 99 99999 9999")]
-        public void IsPhoneFormat_Valid(string value, string formatNumber)
+        public void IsPhoneFormat_IsValid(string value, string formatNumber)
         {
             var right = new Contract()
                 .IsPhone(value, formatNumber, "phone", "Invalid phone");
-            Assert.IsTrue(right.Valid);
+            Assert.IsTrue(right.IsValid);
         }
 
         [TestMethod]
@@ -221,7 +221,7 @@ namespace Flunt.Br.Tests
         {
             var wrong = new Contract()
                 .IsPhone(value, formatNumber, "phone", "Invalid phone");
-            Assert.IsFalse(wrong.Valid);
+            Assert.IsFalse(wrong.IsValid);
         }
 
         [TestMethod]
@@ -232,7 +232,7 @@ namespace Flunt.Br.Tests
         public void IsCellPhone_Invalid(string value)
         {
             var wrong = new Contract().IsCellPhone(value, "cellphone", "Invalid cellphone");
-            Assert.IsFalse(wrong.Valid);
+            Assert.IsFalse(wrong.IsValid);
         }
 
         [TestMethod]
@@ -242,10 +242,10 @@ namespace Flunt.Br.Tests
         [DataRow("+55 (99) 9999-9999")]
         [DataRow("+55 (99) 9999-9999")]
         
-        public void IsCellPhone_Valid(string value)
+        public void IsCellPhone_IsValid(string value)
         {
             var right = new Contract().IsCellPhone(value, "cellphone", "Invalid cellphone");
-            Assert.IsTrue(right.Valid);
+            Assert.IsTrue(right.IsValid);
         }
 
         [TestMethod]
@@ -259,7 +259,7 @@ namespace Flunt.Br.Tests
         public void IsNewCellPhone_Invalid(string value)
         {
             var wrong = new Contract().IsNewFormatCellPhone(value, "cellphone", "Invalid cellphone");
-            Assert.IsFalse(wrong.Valid);
+            Assert.IsFalse(wrong.IsValid);
         }
 
         [TestMethod]
@@ -269,10 +269,10 @@ namespace Flunt.Br.Tests
         [DataRow("+55 (99) 9-9999-9999")]
         [DataRow("+55 (99) 9 9999-9999")]
 
-        public void IsNewCellPhone_Valid(string value)
+        public void IsNewCellPhone_IsValid(string value)
         {
             var right = new Contract().IsNewFormatCellPhone(value, "cellphone", "Invalid cellphone");
-            Assert.IsTrue(right.Valid);
+            Assert.IsTrue(right.IsValid);
         }
 
     }

--- a/tests/Flunt.Br.Tests/StreetContractTest.cs
+++ b/tests/Flunt.Br.Tests/StreetContractTest.cs
@@ -19,7 +19,7 @@ namespace Flunt.Br.Tests
         public void IsCep_InValid(string cep)
         {
             var wrong = new Contract().IsCep(cep, "Cep", "Invalid Cep");
-            Assert.IsFalse(wrong.Valid);
+            Assert.IsFalse(wrong.IsValid);
         }
 
         [TestMethod]
@@ -28,7 +28,7 @@ namespace Flunt.Br.Tests
         public void IsCep_Valid(string cep)
         {
             var right = new Contract().IsCep(cep, "Cep", "Invalid Cep");
-            Assert.IsTrue(right.Valid);
+            Assert.IsTrue(right.IsValid);
         }
     }
 }


### PR DESCRIPTION
Created a Contract class that extends Flunt's `Contract<T>`  to remove the code break caused.

```c#
namespace Flunt.Br
{
    /// <summary>
    /// This class extends the Contract<T> of Flunt Package
    /// To avoid breack changes
    /// </summary>
    public class Contract: Contract<bool>
    {
        
    }
}
```